### PR TITLE
PIP v1.1 support (For Issue #9)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@
 
 
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
 
 
 def get_reqs():
-    install_reqs = parse_requirements('requirements.txt')
-    return [str(ir.req) for ir in install_reqs]
+    req_lines = [line.strip() for line in open(
+        'requirements/common.txt').readlines()]
+    return list(filter(None, req_lines))
 
 
 setup(


### PR DESCRIPTION
Helps out with Issue #9.
Currently, you need PIP v1.2 or higher.
This adds support for PIP v1.1 _(Which is what is in the Debian 7.x repo currently)._

## Before
```bash
root@kali /usr/share/wafw00f_git$ pip --version
pip 1.1 from /usr/lib/python2.7/dist-packages (python 2.7)
root@kali /usr/share/wafw00f_git$ python setup.py install                                                                                                         master 
Traceback (most recent call last):
  File "setup.py", line 24, in <module>
    install_requires=get_reqs(),
  File "setup.py", line 10, in get_reqs
    return [str(ir.req) for ir in install_reqs]
  File "/usr/lib/python2.7/dist-packages/pip/req.py", line 1240, in parse_requirements
    skip_regex = options.skip_requirements_regex
AttributeError: 'NoneType' object has no attribute 'skip_requirements_regex'
root@kali /usr/share/wafw00f_git$                                                                                                                             1 ↵ master 
```


-----


## After

```bash
root@kali /usr/share/wafw00f_git$ pip --version                                                                                                                     ✹pip 
pip 1.1 from /usr/lib/python2.7/dist-packages (python 2.7)
root@kali /usr/share/wafw00f_git$ python setup.py install                                                                                                           ✹pip 
running install
Checking .pth file support in /usr/local/lib/python2.7/dist-packages/
/usr/bin/python -E -c pass
TEST PASSED: /usr/local/lib/python2.7/dist-packages/ appears to support .pth files
running bdist_egg
running egg_info
creating wafw00f.egg-info
writing requirements to wafw00f.egg-info/requires.txt
writing wafw00f.egg-info/PKG-INFO
writing top-level names to wafw00f.egg-info/top_level.txt
writing dependency_links to wafw00f.egg-info/dependency_links.txt
writing manifest file 'wafw00f.egg-info/SOURCES.txt'
reading manifest file 'wafw00f.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'wafw00f.egg-info/SOURCES.txt'
installing library code to build/bdist.linux-x86_64/egg
running install_lib
running build_py
creating build
creating build/lib.linux-x86_64-2.7
creating build/lib.linux-x86_64-2.7/wafw00f
copying wafw00f/__init__.py -> build/lib.linux-x86_64-2.7/wafw00f
creating build/lib.linux-x86_64-2.7/wafw00f/lib
copying wafw00f/lib/evillib.py -> build/lib.linux-x86_64-2.7/wafw00f/lib
copying wafw00f/lib/__init__.py -> build/lib.linux-x86_64-2.7/wafw00f/lib
creating build/lib.linux-x86_64-2.7/wafw00f/tests
copying wafw00f/tests/__init__.py -> build/lib.linux-x86_64-2.7/wafw00f/tests
copying wafw00f/tests/test_main.py -> build/lib.linux-x86_64-2.7/wafw00f/tests
creating build/bdist.linux-x86_64
creating build/bdist.linux-x86_64/egg
creating build/bdist.linux-x86_64/egg/wafw00f
creating build/bdist.linux-x86_64/egg/wafw00f/lib
copying build/lib.linux-x86_64-2.7/wafw00f/lib/evillib.py -> build/bdist.linux-x86_64/egg/wafw00f/lib
copying build/lib.linux-x86_64-2.7/wafw00f/lib/__init__.py -> build/bdist.linux-x86_64/egg/wafw00f/lib
creating build/bdist.linux-x86_64/egg/wafw00f/tests
copying build/lib.linux-x86_64-2.7/wafw00f/tests/__init__.py -> build/bdist.linux-x86_64/egg/wafw00f/tests
copying build/lib.linux-x86_64-2.7/wafw00f/tests/test_main.py -> build/bdist.linux-x86_64/egg/wafw00f/tests
copying build/lib.linux-x86_64-2.7/wafw00f/__init__.py -> build/bdist.linux-x86_64/egg/wafw00f
byte-compiling build/bdist.linux-x86_64/egg/wafw00f/lib/evillib.py to evillib.pyc
byte-compiling build/bdist.linux-x86_64/egg/wafw00f/lib/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-x86_64/egg/wafw00f/tests/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-x86_64/egg/wafw00f/tests/test_main.py to test_main.pyc
byte-compiling build/bdist.linux-x86_64/egg/wafw00f/__init__.py to __init__.pyc
creating build/bdist.linux-x86_64/egg/EGG-INFO
installing scripts to build/bdist.linux-x86_64/egg/EGG-INFO/scripts
running install_scripts
running build_scripts
creating build/scripts-2.7
copying and adjusting wafw00f/bin/wafw00f -> build/scripts-2.7
changing mode of build/scripts-2.7/wafw00f from 644 to 755
creating build/bdist.linux-x86_64/egg/EGG-INFO/scripts
copying build/scripts-2.7/wafw00f -> build/bdist.linux-x86_64/egg/EGG-INFO/scripts
changing mode of build/bdist.linux-x86_64/egg/EGG-INFO/scripts/wafw00f to 755
copying wafw00f.egg-info/PKG-INFO -> build/bdist.linux-x86_64/egg/EGG-INFO
copying wafw00f.egg-info/SOURCES.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying wafw00f.egg-info/dependency_links.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying wafw00f.egg-info/requires.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying wafw00f.egg-info/top_level.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
zip_safe flag not set; analyzing archive contents...
creating dist
creating 'dist/wafw00f-0.9.2-py2.7.egg' and adding 'build/bdist.linux-x86_64/egg' to it
removing 'build/bdist.linux-x86_64/egg' (and everything under it)
Processing wafw00f-0.9.2-py2.7.egg
creating /usr/local/lib/python2.7/dist-packages/wafw00f-0.9.2-py2.7.egg
Extracting wafw00f-0.9.2-py2.7.egg to /usr/local/lib/python2.7/dist-packages
Adding wafw00f 0.9.2 to easy-install.pth file
Installing wafw00f script to /usr/local/bin

Installed /usr/local/lib/python2.7/dist-packages/wafw00f-0.9.2-py2.7.egg
Processing dependencies for wafw00f==0.9.2
Searching for beautifulsoup4==4.3.2
Reading http://pypi.python.org/simple/beautifulsoup4/
Best match: beautifulsoup4 4.3.2
Downloading https://pypi.python.org/packages/source/b/beautifulsoup4/beautifulsoup4-4.3.2.tar.gz#md5=b8d157a204d56512a4cc196e53e7d8ee
Processing beautifulsoup4-4.3.2.tar.gz
Running beautifulsoup4-4.3.2/setup.py -q bdist_egg --dist-dir /tmp/easy_install-QObo0N/beautifulsoup4-4.3.2/egg-dist-tmp-B3Klbs
zip_safe flag not set; analyzing archive contents...
Adding beautifulsoup4 4.3.2 to easy-install.pth file

Installed /usr/local/lib/python2.7/dist-packages/beautifulsoup4-4.3.2-py2.7.egg
Finished processing dependencies for wafw00f==0.9.2
root@kali /usr/share/wafw00f_git$
```