### PR TITLE
Newer F5 BIG-IP ASM releases use 8 char cookies

### DIFF
--- a/wafw00f/plugins/f5bigipasm.py
+++ b/wafw00f/plugins/f5bigipasm.py
@@ -6,4 +6,4 @@ NAME = 'F5 BIG-IP ASM'
 
 def is_waf(self):
     # credit goes to W3AF
-    return self.matchcookie('^TS[a-zA-Z0-9]{3,6}=')
+    return self.matchcookie('^TS[a-zA-Z0-9]{3,8}=')


### PR DESCRIPTION
[This page](https://support.f5.com/kb/en-us/solutions/public/6000/800/sol6850.html)
on F5's site has some new details on how ASM boxes set cookies, basically:

> - In BIG-IP ASM 11.3.0 and later:  (TSxxxxxxxx) The Main ASM cookie name structure contains eight hexadecimal characters.
> - In BIG-IP ASM 10.x - 11.2.1: (TSxxxxxx) The cookie contains six characters that are a hexadecimal representation of the httpclass name that holds the active security policy.

This means that you can use the length of the cookie to do basic version
detection (although I don't think waf200f currently support this).

This commit allows up to 8 hex chars in the TS cookie. 

There are also some other cookies mentioned in the docs, but I've not seen them in the wild.