### PR TITLE
add plugin: NSFocus

### DIFF
--- a/wafw00f/main.py
+++ b/wafw00f/main.py
@@ -320,7 +320,7 @@ class WafW00F(waftoolsengine):
                          'Trustwave ModSecurity', 'IBM Web Application Security', 'IBM DataPower', 'DenyALL WAF',
                          'Applicure dotDefender', 'Juniper WebApp Secure',  # removed for now 'ModSecurity (positive model)',
                          'Microsoft URLScan', 'Aqtronix WebKnight',
-                         'eEye Digital Security SecureIIS', 'Imperva SecureSphere', 'Microsoft ISA Server']
+                         'eEye Digital Security SecureIIS', 'Imperva SecureSphere', 'Microsoft ISA Server', 'NSFocus']
 
     plugin_dict = load_plugins()
     result_dict = {}

--- a/wafw00f/plugins/nsfocus.py
+++ b/wafw00f/plugins/nsfocus.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+
+NAME = 'NSFocus'
+
+
+def is_waf(self):
+    if self.matchheader(('server', 'NSFocus')):
+        return True
+    return False


### PR DESCRIPTION
This plugin detects NSFocus.

Homepage:
* http://nsfocusglobal.com/

I've tested this plugin on a simple HTTP server with spoofed `server` header. I haven't tested this plugin on the WAF as I don't have a test WAF upon which to test.

Implemented based on:
* https://github.com/urbanadventurer/WhatWeb/tree/master/plugins/NSFocus.rb

### Output

```
root@kali:/pentest/web/wafw00f# wafw00f http://127.0.0.1:8080/ 

                                 ^     ^
        _   __  _   ____ _   __  _    _   ____
       ///7/ /.' \ / __////7/ /,' \ ,' \ / __/
      | V V // o // _/ | V V // 0 // 0 // _/
      |_n_,'/_n_//_/   |_n_,' \_,' \_,'/_/
                                <
                                 ...'

    WAFW00F - Web Application Firewall Detection Tool

    By Sandro Gauci && Wendel G. Henrique

Checking http://127.0.0.1:8080/
The site http://127.0.0.1:8080/ is behind a Imperva SecureSphere
Number of requests: 8
```

```
root@kali:/pentest/web/wafw00f# wafw00f http://127.0.0.1:8080/ -a 

                                 ^     ^
        _   __  _   ____ _   __  _    _   ____
       ///7/ /.' \ / __////7/ /,' \ ,' \ / __/
      | V V // o // _/ | V V // 0 // 0 // _/
      |_n_,'/_n_//_/   |_n_,' \_,' \_,'/_/
                                <
                                 ...'

    WAFW00F - Web Application Firewall Detection Tool

    By Sandro Gauci && Wendel G. Henrique

Checking http://127.0.0.1:8080/
The site http://127.0.0.1:8080/ is behind a Imperva SecureSphere and/or NSFocus
Generic Detection results:
The site http://127.0.0.1:8080/ seems to be behind a WAF or some sort of security solution
Reason: Blocking is being done at connection/packet level.
Number of requests: 11
```