### PR TITLE
add plugin: Safedog

### DIFF
--- a/wafw00f/main.py
+++ b/wafw00f/main.py
@@ -313,7 +313,7 @@ class WafW00F(waftoolsengine):
     # lil bit more complex
     #wafdetections['BeeWare'] = isbeeware
     #wafdetections['ModSecurity (positive model)'] = ismodsecuritypositive removed for now
-    wafdetectionsprio = ['Profense', 'NetContinuum', 'Incapsula WAF', 'CloudFlare', 'NSFocus',
+    wafdetectionsprio = ['Profense', 'NetContinuum', 'Incapsula WAF', 'CloudFlare', 'NSFocus', 'Safedog',
                          'Mission Control Application Shield', 'USP Secure Entry Server', 'Cisco ACE XML Gateway',
                          'Barracuda Application Firewall', 'Art of Defence HyperGuard', 'BinarySec', 'Teros WAF',
                          'F5 BIG-IP LTM', 'F5 BIG-IP APM', 'F5 BIG-IP ASM', 'F5 FirePass', 'F5 Trafficshield', 

--- a/wafw00f/plugins/safedog.py
+++ b/wafw00f/plugins/safedog.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+
+NAME = 'Safedog'
+
+
+def is_waf(self):
+    if self.matchcookie('^safedog-flow-item='):
+        return True
+    if self.matchheader(('server', '^Safedog')):
+        return True
+    if self.matchheader(('x-powered-by', '^WAF/\d\.\d')):
+        return True
+    return False


### PR DESCRIPTION
This plugin detects Safedog.

* Homepage: http://safedog.cn/

I've tested this plugin on a simple HTTP server with spoofed `server`, `x-powered-by` and `set-cookie` headers. I haven't tested this plugin on the WAF as I don't have a test WAF upon which to test.

### Output

```
./wafw00f/bin/wafw00f 127.0.0.1:8080 

                                 ^     ^
        _   __  _   ____ _   __  _    _   ____
       ///7/ /.' \ / __////7/ /,' \ ,' \ / __/
      | V V // o // _/ | V V // 0 // 0 // _/
      |_n_,'/_n_//_/   |_n_,' \_,' \_,'/_/
                                <
                                 ...'

    WAFW00F - Web Application Firewall Detection Tool

    By Sandro Gauci && Wendel G. Henrique

Checking http://127.0.0.1:8080
The site http://127.0.0.1:8080 is behind a Safedog
Number of requests: 1
```
