### PR TITLE
Add support for HTTP and socks5 proxies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     packages=find_packages(),
     scripts=['wafw00f/bin/wafw00f'],
     install_requires=[
-        'beautifulsoup4==4.3.2',
+        'beautifulsoup4==4.4.1',
         'pluginbase==0.3',
     ],
     extras_require={

--- a/wafw00f/lib/evillib.py
+++ b/wafw00f/lib/evillib.py
@@ -264,7 +264,7 @@ class waftoolsengine:
                 port = 443
             else:
                 port = 80
-        self.port = port
+        self.port = int(port)
         self.ssl = ssl
         self.debuglevel = debuglevel
         self.cachedresponses = dict()

--- a/wafw00f/lib/evillib.py
+++ b/wafw00f/lib/evillib.py
@@ -18,7 +18,7 @@ except ImportError:
     sys.exit(1)
 
 
-from .proxy import NullProxy, HttpProxy, Socks5Proxy, httplib
+from .proxy import NullProxy, HttpProxy, Socks5Proxy, httplib, socks
 
 __license__ = """
 Copyright (c) 2014, {Sandro Gauci|Wendel G. Henrique}
@@ -442,14 +442,14 @@ class waftoolsengine:
 
         try:
             if parts.scheme == "socks5":
-                import socks
+                if socks is None:
+                    raise Exception("socks5 proxy requires PySocks")
+
                 return Socks5Proxy(netloc[0], int(netloc[1]))
             elif parts.scheme == "http":
                 return HttpProxy(netloc[0], int(netloc[1]))
             else:
                 raise Exception("Unsupported proxy scheme")
-        except ImportError:
-            raise Exception("socks5 proxy requires PySocks")
         except ValueError:
             raise Exception("Invalid port number")
 

--- a/wafw00f/lib/evillib.py
+++ b/wafw00f/lib/evillib.py
@@ -2,10 +2,6 @@
 import re
 import sys
 
-try:
-    import httplib
-except ImportError:
-    import http.client as httplib
 import socket
 
 try:
@@ -20,6 +16,9 @@ except ImportError:
     sys.stderr.write('You need to get BeautifulSoup installed\n')
     sys.stderr.write('Do it now, as privileged user/root run: pip install beautifulsoup4\now')
     sys.exit(1)
+
+
+from .proxy import NullProxy, HttpProxy, Socks5Proxy, httplib
 
 __license__ = """
 Copyright (c) 2014, {Sandro Gauci|Wendel G. Henrique}
@@ -150,6 +149,7 @@ homoglyphicmapping = {"'": '%ca%bc'}
 
 def oururlparse(target):
     log = logging.getLogger('urlparser')
+
     ssl = False
     o = urlparse(target)
     if o[0] not in ['http', 'https', '']:
@@ -251,7 +251,8 @@ def backslashquotes(ourstr):
 
 class waftoolsengine:
     def __init__(self, target='www.microsoft.com', port=80, ssl=False,
-                 debuglevel=0, path='/', followredirect=True, extraheaders={}):
+                 debuglevel=0, path='/', followredirect=True, extraheaders={},
+                 proxy=False):
         """
         target: the hostname or ip of the target server
         port: defaults to 80
@@ -273,6 +274,12 @@ class waftoolsengine:
         self.followredirect = followredirect
         self.crawlpaths = list()
         self.extraheaders = extraheaders
+
+        try:
+            self.proxy = self._parse_proxy(proxy) if proxy else NullProxy()
+        except Exception as e:
+            self.log.critical("Proxy disabled: %s" % e)
+            self.proxy = NullProxy()
 
     def request(self, method='GET', path=None, usecache=True,
                 cacheresponse=True, headers=None,
@@ -310,37 +317,13 @@ class waftoolsengine:
                 return self.cachedresponses[k]
             else:
                 self.log.debug('%s not found in %s' % (k, self.cachedresponses.keys()))
-        if sys.hexversion > 0x2060000:
-            if self.ssl:
-                h = httplib.HTTPSConnection(self.target, self.port, timeout=4)
-            else:
-                h = httplib.HTTPConnection(self.target, self.port, timeout=4)
-        else:
-            if self.ssl:
-                h = httplib.HTTPSConnection(self.target, self.port)
-            else:
-                h = httplib.HTTPConnection(self.target, self.port)
-        if self.debuglevel <= 10:
-            if self.debuglevel > 1:
-                h.set_debuglevel(self.debuglevel)
-        try:
-            self.log.info('Sending %s %s' % (method, path))
-            h.request(method, path, headers=headers)
-        except socket.error:
-            self.log.warn('Could not initialize connection to %s' % self.target)
-            return
-        self.requestnumber += 1
-        try:
-            response = h.getresponse()
-            responsebody = response.read()
-            h.close()
-            r = response, responsebody
-        except (socket.error, socket.timeout, httplib.BadStatusLine):
-            self.log.warn('Hey.. they closed our connection!')
-            r = None
+
+        r = self._request(method, path, headers)
         if cacheresponse:
             self.cachedresponses[k] = r
+
         if r:
+            response, responsebody = r
             if response.status in [301, 302, 307]:
                 if followredirect:
                     if response.getheader('location'):
@@ -363,6 +346,40 @@ class waftoolsengine:
                                 self.log.warn('Tried to redirect to a different server %s' % newloc)
                         else:
                             self.log.warn('%s is not a well formatted url' % response.getheader('location'))
+        return r
+
+    def _request(self, method, path, headers):
+        original_socket = socket.socket
+        try:
+            conn_factory, connect_host, connect_port, query_path = \
+                    self.proxy.prepare(self.target, self.port, path, self.ssl)
+
+            if sys.hexversion > 0x2060000:
+                h = conn_factory(connect_host, connect_port, timeout=4)
+            else:
+                h = conn_factory(connect_host, connect_port)
+
+            if self.debuglevel <= 10:
+                if self.debuglevel > 1:
+                    h.set_debuglevel(self.debuglevel)
+            try:
+                self.log.info('Sending %s %s' % (method, path))
+                h.request(method, query_path, headers=headers)
+            except socket.error:
+                self.log.warn('Could not initialize connection to %s' % self.target)
+                return
+            self.requestnumber += 1
+
+            response = h.getresponse()
+            responsebody = response.read()
+            h.close()
+            r = response, responsebody
+        except (socket.error, socket.timeout, httplib.BadStatusLine):
+            self.log.warn('Hey.. they closed our connection!')
+            r = None
+        finally:
+            self.proxy.terminate()
+
         return r
 
 
@@ -413,6 +430,29 @@ class waftoolsengine:
             r = self.querycrawler(path=nextpath, curdepth=curdepth + 1, maxdepth=maxdepth)
             if r:
                 return r
+
+    def _parse_proxy(self, proxy):
+        parts = urlparse(proxy)
+        if not parts.scheme or not parts.netloc:
+            raise Exception("Invalid proxy specified, scheme required")
+        
+        netloc = parts.netloc.split(":")
+        if len(netloc) != 2:
+            raise Exception("Proxy port unspecified")
+
+        try:
+            if parts.scheme == "socks5":
+                import socks
+                return Socks5Proxy(netloc[0], int(netloc[1]))
+            elif parts.scheme == "http":
+                return HttpProxy(netloc[0], int(netloc[1]))
+            else:
+                raise Exception("Unsupported proxy scheme")
+        except ImportError:
+            raise Exception("socks5 proxy requires PySocks")
+        except ValueError:
+            raise Exception("Invalid port number")
+
 
 
 def scrambledheader(header):

--- a/wafw00f/lib/proxy.py
+++ b/wafw00f/lib/proxy.py
@@ -1,0 +1,52 @@
+try:
+    import httplib
+except ImportError:
+    import http.client as httplib
+
+
+class NullProxy:
+
+    def prepare(self, target, port, path, ssl):
+        conn_factory = httplib.HTTPSConnection if ssl else httplib.HTTPConnection
+        return conn_factory, target, port, path
+    
+    def terminate(self):
+        pass
+
+
+class HttpProxy:
+
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+
+    def prepare(self, target, port, path, ssl):
+        conn_factory = httplib.HTTPConnection
+        query_path = "%(scheme)s://%(host)s%(path)s" % dict(
+                scheme="https" if ssl else "http",
+                host=target,
+                path=path)
+        return conn_factory, self.host, self.port, query_path
+    
+    def terminate(self):
+        pass
+
+
+class Socks5Proxy:
+
+    def __init__(self, host, port):
+        import socket
+        self.host = host
+        self.port = port
+        self.original = socket.socket
+
+    def prepare(self, target, port, path, ssl):
+        import socks
+        socks.setdefaultproxy(socks.PROXY_TYPE_SOCKS5, self.host, self.port)
+        httplib.socket.socket = socks.socksocket
+
+        conn_factory = httplib.HTTPSConnection if ssl else httplib.HTTPConnection
+        return conn_factory, target, port, path
+    
+    def terminate(self):
+        httplib.socket.socket = self.original

--- a/wafw00f/lib/proxy.py
+++ b/wafw00f/lib/proxy.py
@@ -1,7 +1,14 @@
+import socket
+
 try:
     import httplib
 except ImportError:
     import http.client as httplib
+
+try:
+    import socks
+except ImportError:
+    socks = None
 
 
 class NullProxy:
@@ -35,18 +42,22 @@ class HttpProxy:
 class Socks5Proxy:
 
     def __init__(self, host, port):
-        import socket
         self.host = host
         self.port = port
         self.original = socket.socket
+        self.original_create = socket.create_connection
 
     def prepare(self, target, port, path, ssl):
-        import socks
+        def proxy_create_connection(address, timeout=4, source_address=None):
+            return socks.create_connection(address, proxy_type=socks.PROXY_TYPE_SOCKS5, proxy_addr=self.host, proxy_port=self.port, source_address=source_address, timeout=timeout)
+
         socks.setdefaultproxy(socks.PROXY_TYPE_SOCKS5, self.host, self.port)
         httplib.socket.socket = socks.socksocket
+        httplib.socket.create_connection = proxy_create_connection
 
         conn_factory = httplib.HTTPSConnection if ssl else httplib.HTTPConnection
         return conn_factory, target, port, path
     
     def terminate(self):
         httplib.socket.socket = self.original
+        httplib.socket.create_connection = self.original_create


### PR DESCRIPTION
Optionally allow to specify an http or socks5 proxy.

* -p http://hostname:8080
* -p socks5://hostname:1080

Some minor changes were made to improve python3.5 compatibility.