### PR TITLE
Add mod_security plugin with OWASP CRS base rules

### DIFF
--- a/wafw00f/main.py
+++ b/wafw00f/main.py
@@ -330,7 +330,12 @@ class WafW00F(waftoolsengine):
 
     def identwaf(self, findall=False):
         detected = list()
-        for wafvendor in self.wafdetectionsprio:
+
+        # Check for prioritized ones first, then check those added externally
+        checklist = self.wafdetectionsprio
+        checklist = checklist + list(set(self.wafdetections.keys()) - set(checklist))
+
+        for wafvendor in checklist:
             self.log.info('Checking for %s' % wafvendor)
             if self.wafdetections[wafvendor](self):
                 detected.append(wafvendor)

--- a/wafw00f/plugins/modsecuritycrs.py
+++ b/wafw00f/plugins/modsecuritycrs.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+
+NAME = 'ModSecurity (OWASP CRS)'
+
+
+def is_waf(self):
+    detected = False
+    r = self.request('GET', '/?id=' + self.xssstring)
+    if r is None:
+        return False
+
+    normalresponse, _ = self.normalrequest()
+    response, _ = r
+
+    return normalresponse.status != response.status


### PR DESCRIPTION
Mod security with basic rules was not being detected. Generic detection missed it too. This plugin checks for a variation when the attack is in arbitrary query argument.

Additionally, I slightly altered the checking logic so plugins not hardcoded in main.py also get executed.