### PR TITLE
Detect presence of better-wp-security

### DIFF
--- a/wafw00f/plugins/betterwpsecurity.py
+++ b/wafw00f/plugins/betterwpsecurity.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+
+NAME = 'Better WP Security'
+
+
+def is_waf(self):
+    normalresponse, _ = self.normalrequest()
+    link_header = normalresponse.getheader('Link') or ""
+
+    if "https://api.w.org/" not in link_header:
+        # Does not appear to be a wordpress at all
+        return False
+
+    r = self.request("GET", "/wp-content/plugins/better-wp-security/")
+
+    if not r:
+        return False
+
+    pluginresponse, _ = r
+
+    return pluginresponse.status == 200


### PR DESCRIPTION
This wordpress plugin can be ban users scanning sites.

The check performs an additional request only if the site appears to be a wordpress site.