### PR TITLE
Make sure base path is respected for modsec and betterwpsec plugins

### DIFF
--- a/wafw00f/plugins/betterwpsecurity.py
+++ b/wafw00f/plugins/betterwpsecurity.py
@@ -12,7 +12,7 @@ def is_waf(self):
         # Does not appear to be a wordpress at all
         return False
 
-    r = self.request("GET", "/wp-content/plugins/better-wp-security/")
+    r = self.request("GET", self.path + "wp-content/plugins/better-wp-security/")
 
     if not r:
         return False

--- a/wafw00f/plugins/modsecuritycrs.py
+++ b/wafw00f/plugins/modsecuritycrs.py
@@ -6,7 +6,7 @@ NAME = 'ModSecurity (OWASP CRS)'
 
 def is_waf(self):
     detected = False
-    r = self.request('GET', '/?id=' + self.xssstring)
+    r = self.request('GET', self.path + '?id=' + self.xssstring)
     if r is None:
         return False
 


### PR DESCRIPTION
My previous contributions omitted to include self.path as part of the base path, which caused false positives in some cases for modsec, and failures to detect for betterwpsec.